### PR TITLE
fix: include missing boolean type in JSONValue union

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -477,6 +477,7 @@ declare namespace postgres {
     | null
     | string
     | number
+    | boolean
     | Date // serialized as `string`
     | readonly JSONValue[]
     | { toJSON(): any } // `toJSON` called by `JSON.stringify`; not typing the return type, typings is strict enough anyway


### PR DESCRIPTION
Running workflow on my own account.